### PR TITLE
Login retry if 401

### DIFF
--- a/empowering/executors/urllib2_executor.py
+++ b/empowering/executors/urllib2_executor.py
@@ -100,3 +100,11 @@ class HTTPAuthEmpowering(urllib2.BaseHandler):
         req.headers['Cookie'] = "iPlanetDirectoryPro={}".format(auth['token'])
         return self.parent.open(req, timeout=req.timeout)
 
+
+class Urllib2Executor(urllib2_executor.Urllib2Executor):
+    def __init__(self, extra_handlers):
+        self.handlers = extra_handlers
+
+
+def use(extra_handlers=()):
+    base.use_executor(Urllib2Executor(extra_handlers=extra_handlers))

--- a/empowering/executors/urllib2_executor.py
+++ b/empowering/executors/urllib2_executor.py
@@ -26,6 +26,9 @@ class HTTPSClientAuthHandler(urllib2.HTTPSHandler):
         return self.do_open(self.getConnection, req)
 
     def getConnection(self, host, timeout=300):
+        logger.debug('using https connection (key file:{} Cert file:{})'.format(
+            self.key_file, self.cert_file
+        ))
         return httplib.HTTPSConnection(host, key_file=self.key_file,
                                        cert_file=self.cert_file)
 

--- a/empowering/executors/urllib2_executor.py
+++ b/empowering/executors/urllib2_executor.py
@@ -47,9 +47,10 @@ class HTTPEmpoweringFilterHandler(urllib2.BaseHandler):
                 url.fragment
             ))
             logger.debug("New url set to %s" % newurl)
-            newr = RequestWithMethod(newurl, request.data, request.headers,
-                                    request.origin_req_host,
-                                    request.unverifiable)
+            newr = urllib2_executor.RequestWithMethod(
+                newurl, request.data, request.headers, request.origin_req_host,
+                request.unverifiable
+            )
             newr.timeout = request.timeout
             newr.set_method(request.get_method())
             return newr


### PR DESCRIPTION
Implement a AuthHandler when a 401 is raised.

You can test doing:

```python
import logging
from empowering import Empowering
logging.basicConfig(level=logging.DEBUG)
em = Empowering("XXXXX", "XXXXX", "XXXXX", key_file="file.pem", cert_file="file.pem")
print "TOKEN", em.token
em.contract("XXXXX").get()
em.logout()
print "LOGOUT"
em.contract("XXXXX").get()
print "TOKEN", em.token
```

Fixes #15 