### PR TITLE
FIX urllib executor only for empowering api

### DIFF
--- a/empowering/executors/urllib2_executor.py
+++ b/empowering/executors/urllib2_executor.py
@@ -5,8 +5,10 @@ import json
 from urlparse import urlparse, urlunparse
 from libsaas.executors import base, urllib2_executor
 
-
 logger = logging.getLogger('empowering.executors.urllib2_executor')
+
+API_HOST = 'api.empowering.cimne.com'
+DEBUG_API_HOST = '91.121.140.152'
 
 
 class HTTPSClientAuthHandler(urllib2.HTTPSHandler):
@@ -26,6 +28,9 @@ class HTTPSClientAuthHandler(urllib2.HTTPSHandler):
         return self.do_open(self.getConnection, req)
 
     def getConnection(self, host, timeout=300):
+        if host not in (API_HOST, DEBUG_API_HOST):
+            res = httplib.HTTPSConnection(host)
+            return res
         logger.debug('using https connection (key file:{} Cert file:{})'.format(
             self.key_file, self.cert_file
         ))

--- a/empowering/service.py
+++ b/empowering/service.py
@@ -16,6 +16,7 @@ from libsaas.executors import urllib2_executor as base_executor
 from empowering.executors import urllib2_executor
 from empowering.executors.urllib2_executor import (
     HTTPSClientAuthHandler, HTTPEmpoweringFilterHandler, HTTPAuthEmpowering,
+    API_HOST, DEBUG_API_HOST
 )
 from empowering.resource import EmpoweringResource
 from empowering.results import *
@@ -81,9 +82,9 @@ class Empowering(base.Resource):
         self.key_file = key_file
         self.cert_file = cert_file
         self.version = version
-        self.apiroot = "https://api.empowering.cimne.com"
+        self.apiroot = "https://{0}".format(API_HOST)
         if debug:
-            self.apiroot = "https://91.121.140.152"
+            self.apiroot = "https://{0}".format(DEBUG_API_HOST)
         self.login_handler = None
         self.add_filter(self.use_json)
         self.add_filter(self.add_company_id)


### PR DESCRIPTION
The executor defined for empowering is used in others lib's using libsaas. 